### PR TITLE
Remove dependency on internal Gradle API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'maven-publish'
 }
 
-version = '1.0.0'
+version = '1.0.1-SNAPSHOT'
 group = 'ru.kinca.gradle'
 
 repositories {


### PR DESCRIPTION
In recent versions of Gradle, breaking changes have been made
DefaultPropertyState. This commit removes the usage of
DefaultPropertyState, allowing this plugin to work correctly on newer
versions of Gradle.